### PR TITLE
fix: `data_commitment` input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "array-macro"
-version = "2.1.5"
+version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457661fa6716c30b73d7c41400a8a78780d20523b83a9441dabec28e93f27cf4"
+checksum = "220a2c618ab466efe41d0eace94dfeff1c35e3aa47891bdb95e1c0fefffd3c99"
 
 [[package]]
 name = "arrayvec"
@@ -353,7 +353,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -699,7 +699,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -966,7 +966,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1003,7 +1003,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1014,7 +1014,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1296,9 +1296,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1440,7 +1440,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.38",
+ "syn 2.0.39",
  "toml",
  "walkdir",
 ]
@@ -1458,7 +1458,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1484,7 +1484,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.38",
+ "syn 2.0.39",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -1679,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a481586acf778f1b1455424c343f71124b048ffa5f4fc3f8f6ae9dc432dcb3c7"
+checksum = "f69037fe1b785e84986b4f2cbcf647381876a00671d25ceef715d7812dd7e1dd"
 
 [[package]]
 name = "fixed-hash"
@@ -1842,7 +1842,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1907,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2408,9 +2408,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libm"
@@ -2419,10 +2419,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.10"
+name = "libredox"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
@@ -2654,7 +2665,7 @@ dependencies = [
  "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2726,7 +2737,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2803,7 +2814,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
  "windows-targets",
 ]
@@ -2929,7 +2940,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2967,7 +2978,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3007,7 +3018,7 @@ checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/mir-protocol/plonky2.git#5d5628b59d99c7119333f85b39f24c82ca541c10"
+source = "git+https://github.com/mir-protocol/plonky2.git#954d1a77c6fa9068ec14fc25e4d0b3b8a63558fb"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3031,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git#5d5628b59d99c7119333f85b39f24c82ca541c10"
+source = "git+https://github.com/mir-protocol/plonky2.git#954d1a77c6fa9068ec14fc25e4d0b3b8a63558fb"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -3055,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git#5d5628b59d99c7119333f85b39f24c82ca541c10"
+source = "git+https://github.com/mir-protocol/plonky2.git#954d1a77c6fa9068ec14fc25e4d0b3b8a63558fb"
 dependencies = [
  "rayon",
 ]
@@ -3063,7 +3074,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.1"
-source = "git+https://github.com/mir-protocol/plonky2.git#5d5628b59d99c7119333f85b39f24c82ca541c10"
+source = "git+https://github.com/mir-protocol/plonky2.git#954d1a77c6fa9068ec14fc25e4d0b3b8a63558fb"
 
 [[package]]
 name = "plonky2x"
@@ -3114,7 +3125,7 @@ source = "git+https://github.com/succinctlabs/succinctx.git#aab74a105311d2f8236c
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3142,7 +3153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3355,15 +3366,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -3373,12 +3375,12 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.16",
+ "libredox",
  "thiserror",
 ]
 
@@ -3839,7 +3841,7 @@ checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3870,7 +3872,7 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3920,7 +3922,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4151,7 +4153,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4190,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "svm-rs"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0cc95be7cc2c384a2f57cac56548d2178650905ebe5725bc8970ccc25529060"
+checksum = "20689c7d03b6461b502d0b95d6c24874c7d24dea2688af80486a130a06af3b07"
 dependencies = [
  "dirs",
  "fs2",
@@ -4221,9 +4223,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4239,7 +4241,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4277,7 +4279,7 @@ checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "rustix",
  "windows-sys",
 ]
@@ -4332,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "tendermintx"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/tendermintx.git#8df5f8f51a839256fee4f0d413f44714cfa0d3b0"
+source = "git+https://github.com/succinctlabs/tendermintx.git#50fa1e0994a3549711d3c0a601a02a8c37c54aa8"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4400,7 +4402,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4493,7 +4495,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4615,7 +4617,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4883,7 +4885,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -4917,7 +4919,7 @@ checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5105,22 +5107,22 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.24"
+version = "0.7.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092cd76b01a033a9965b9097da258689d9e17c69ded5dcf41bca001dd20ebc6d"
+checksum = "8cd369a67c0edfef15010f980c3cbe45d7f651deac2cd67ce097cd801de16557"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.24"
+version = "0.7.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13a20a7c6a90e2034bcc65495799da92efcec6a8dd4f3fcb6f7a48988637ead"
+checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -5140,7 +5142,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ Deploy a `BlobstreamX` contract.
 forge create --rpc-url $RPC_URL --private-key $PRIVATE_KEY --constructor-args 0x6e4f1e9ea315ebfd69d18c2db974eef6105fb803 --etherscan-api-key $ETHERSCAN_API_KEY --verify BlobstreamX
 ```
 
-Initialize `BlobstreamX` contract with genesis parameters from forge script.
+Initialize `BlobstreamX` contract with genesis parameters.
 ```
-forge script script/BlobstreamX.s.sol --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast
+forge script script/Deploy.s.sol --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast
+```
+
+Update the function ID's on the `BlobstreamX` contract.
+```
+forge script script/FunctionId.s.sol --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast
 ```
 
 Update .env file with contract address and chain id.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Blobstream X
 Implementation of zero-knowledge proof circuits for [Blobstream](https://docs.celestia.org/nodes/blobstream-intro/), Celestia's data availability solution for Ethereum.
 
-## Overview (wip)
+## Overview
 Blobstream X's core contract is `BlobstreamX`, which stores commitments to ranges of data roots from Celestia blocks. Users can query the for the validity of a data root of a specific block height via `verifyAttestation`, which proves that the data root is a leaf in the Merkle tree for the block range the specific block height is in.
 
-### headerRange (wip)
+### headerRange
 `headerRange` is used to generate the data root of a block range. The data root is the root of a Merkle tree of the data roots of all the blocks in the block range. 
 
 To prove the last header of a block range, `headerRange` uses `skip` as a sub-circuit. After proving the last header, the `headerRange` circuit proves the chain of headers from the start header to the last header. From a valid chain of headers, the `headerRange` circuit can generate the commitment of the block range with the data root of each block in the block range.
 
-### nextHeader (wip)
+### nextHeader
 `nextHeader` is used to generate the commitment to the data root of the current block.
 
 This is rarely used, as `nextHeader` will only be invoked when the validator set changes by more than 2/3 in a single block.

--- a/abi/BlobstreamX.abi.json
+++ b/abi/BlobstreamX.abi.json
@@ -12,6 +12,11 @@
     },
     {
         "inputs": [],
+        "name": "DataCommitmentNotFound",
+        "type": "error"
+    },
+    {
+        "inputs": [],
         "name": "LatestHeaderNotFound",
         "type": "error"
     },
@@ -26,8 +31,19 @@
         "type": "error"
     },
     {
+        "inputs": [],
+        "name": "TrustedHeaderNotFound",
+        "type": "error"
+    },
+    {
         "anonymous": false,
         "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "proofNonce",
+                "type": "uint256"
+            },
             {
                 "indexed": true,
                 "internalType": "uint64",
@@ -197,11 +213,6 @@
                 "type": "uint64"
             },
             {
-                "internalType": "bytes32",
-                "name": "_trustedHeader",
-                "type": "bytes32"
-            },
-            {
                 "internalType": "uint64",
                 "name": "_targetBlock",
                 "type": "uint64"
@@ -218,11 +229,6 @@
                 "internalType": "uint64",
                 "name": "_trustedBlock",
                 "type": "uint64"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "_trustedHeader",
-                "type": "bytes32"
             }
         ],
         "name": "commitNextHeader",
@@ -238,12 +244,12 @@
                 "type": "bytes32"
             }
         ],
-        "name": "dataCommitments",
+        "name": "dataCommitmentNonces",
         "outputs": [
             {
-                "internalType": "bytes32",
+                "internalType": "uint256",
                 "name": "",
-                "type": "bytes32"
+                "type": "uint256"
             }
         ],
         "stateMutability": "view",
@@ -385,6 +391,38 @@
     {
         "inputs": [
             {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "name": "state_dataCommitments",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "state_proofNonce",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
                 "internalType": "address",
                 "name": "_gateway",
                 "type": "address"
@@ -425,12 +463,7 @@
         "inputs": [
             {
                 "internalType": "uint256",
-                "name": "_startBlock",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_endBlock",
+                "name": "_proofNonce",
                 "type": "uint256"
             },
             {

--- a/bin/blobstreamx.rs
+++ b/bin/blobstreamx.rs
@@ -159,8 +159,8 @@ impl BlobstreamXOperator {
     }
 
     async fn run(&self) {
-        // Loop every 30 minutes.
-        const LOOP_DELAY: u64 = 30;
+        // Loop every 60 minutes.
+        const LOOP_DELAY: u64 = 60;
 
         let header_range_max = self.contract.data_commitment_max().await.unwrap();
         loop {

--- a/bin/blobstreamx.rs
+++ b/bin/blobstreamx.rs
@@ -104,10 +104,7 @@ impl BlobstreamXOperator {
 
         let input = NextHeaderInputTuple::abi_encode_packed(&(trusted_block, trusted_header_hash));
 
-        let commit_next_header_call = CommitNextHeaderCall {
-            trusted_block,
-            trusted_header: trusted_header_hash,
-        };
+        let commit_next_header_call = CommitNextHeaderCall { trusted_block };
         let function_data = commit_next_header_call.encode();
 
         let request_id = self
@@ -139,7 +136,6 @@ impl BlobstreamXOperator {
 
         let commit_header_range_call = CommitHeaderRangeCall {
             trusted_block,
-            trusted_header: trusted_header_hash,
             target_block,
         };
         let function_data = commit_header_range_call.encode();

--- a/bin/blobstreamx.rs
+++ b/bin/blobstreamx.rs
@@ -60,7 +60,6 @@ impl BlobstreamXOperator {
     fn get_config() -> BlobstreamXConfig {
         let contract_address = env::var("CONTRACT_ADDRESS").expect("CONTRACT_ADDRESS must be set");
         let chain_id = env::var("CHAIN_ID").expect("CHAIN_ID must be set");
-        // TODO: BlobstreamX on Goerli: https://goerli.etherscan.io/address/#code
         let address = contract_address
             .parse::<Address>()
             .expect("invalid address");

--- a/circuits/data_commitment.rs
+++ b/circuits/data_commitment.rs
@@ -180,13 +180,13 @@ mod tests {
         const NB_MAP_JOBS: usize = 2;
         const BATCH_SIZE: usize = 8;
 
-        let start_block = 10000u64;
+        let start_block = 1u64;
         let start_header_hash =
-            hex::decode_upper("A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D")
+            hex::decode_upper("6BE39EFD10BA412A9DB5288488303F5DD32CF386707A5BEF33617F4C43301872")
                 .unwrap();
-        let end_block = 10004u64;
+        let end_block = 5u64;
         let end_header_hash =
-            hex::decode_upper("FCDA37FA6306C77737DD911E6101B612E2DBD837F29ED4F4E1C30919FBAC9D05")
+            hex::decode_upper("6FCBD8C84985E1441F6AFF82DFF9A44B8C756DA5A1F295B444CE19394413D0F8")
                 .unwrap();
 
         test_data_commitment_template::<NB_MAP_JOBS, BATCH_SIZE>(
@@ -205,13 +205,13 @@ mod tests {
         const NB_MAP_JOBS: usize = 16;
         const BATCH_SIZE: usize = 64;
 
-        let start_block = 10000u64;
+        let start_block = 500u64;
         let start_header_hash =
-            hex::decode_upper("A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D")
+            hex::decode_upper("A4580A5609BD420694FB4718645529AC654470489CD4D8BF144C5208EC08819F")
                 .unwrap();
-        let end_block = 10004u64;
+        let end_block = 504u64;
         let end_header_hash =
-            hex::decode_upper("FCDA37FA6306C77737DD911E6101B612E2DBD837F29ED4F4E1C30919FBAC9D05")
+            hex::decode_upper("D6DA719AE76440DD977D6D7E618F71BEF4239D7C5D24A2B7588DFA6227B1EB38")
                 .unwrap();
 
         test_data_commitment_template::<NB_MAP_JOBS, BATCH_SIZE>(
@@ -230,13 +230,13 @@ mod tests {
         const NB_MAP_JOBS: usize = 16;
         const BATCH_SIZE: usize = 16;
 
-        let start_block = 10000u64;
+        let start_block = 500u64;
         let start_header_hash =
-            hex::decode_upper("A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D")
+            hex::decode_upper("A4580A5609BD420694FB4718645529AC654470489CD4D8BF144C5208EC08819F")
                 .unwrap();
-        let end_block = 10004u64;
+        let end_block = 504u64;
         let end_header_hash =
-            hex::decode_upper("FCDA37FA6306C77737DD911E6101B612E2DBD837F29ED4F4E1C30919FBAC9D05")
+            hex::decode_upper("D6DA719AE76440DD977D6D7E618F71BEF4239D7C5D24A2B7588DFA6227B1EB38")
                 .unwrap();
 
         test_data_commitment_template::<NB_MAP_JOBS, BATCH_SIZE>(

--- a/circuits/header_range.rs
+++ b/circuits/header_range.rs
@@ -160,17 +160,17 @@ mod tests {
     #[cfg_attr(feature = "ci", ignore)]
     fn test_header_range_small() {
         // Test variable length NUM_BLOCKS.
-        const MAX_VALIDATOR_SET_SIZE: usize = 4;
+        const MAX_VALIDATOR_SET_SIZE: usize = 8;
         const NB_MAP_JOBS: usize = 2;
         const BATCH_SIZE: usize = 2;
 
-        let start_block = 10000u64;
+        let start_block = 500u64;
         let start_header_hash =
-            hex::decode_upper("A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D")
+            hex::decode_upper("A4580A5609BD420694FB4718645529AC654470489CD4D8BF144C5208EC08819F")
                 .unwrap();
-        let end_block = 10004u64;
+        let end_block = 504u64;
         let _ =
-            hex::decode_upper("FCDA37FA6306C77737DD911E6101B612E2DBD837F29ED4F4E1C30919FBAC9D05")
+            hex::decode_upper("D6DA719AE76440DD977D6D7E618F71BEF4239D7C5D24A2B7588DFA6227B1EB38")
                 .unwrap();
 
         test_header_range_template::<MAX_VALIDATOR_SET_SIZE, NB_MAP_JOBS, BATCH_SIZE>(
@@ -188,13 +188,13 @@ mod tests {
         const NB_MAP_JOBS: usize = 16;
         const BATCH_SIZE: usize = 64;
 
-        let start_block = 10000u64;
+        let start_block = 500u64;
         let start_header_hash =
-            hex::decode_upper("A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D")
+            hex::decode_upper("A4580A5609BD420694FB4718645529AC654470489CD4D8BF144C5208EC08819F")
                 .unwrap();
-        let end_block = 10004u64;
+        let end_block = 504u64;
         let _ =
-            hex::decode_upper("FCDA37FA6306C77737DD911E6101B612E2DBD837F29ED4F4E1C30919FBAC9D05")
+            hex::decode_upper("D6DA719AE76440DD977D6D7E618F71BEF4239D7C5D24A2B7588DFA6227B1EB38")
                 .unwrap();
 
         test_header_range_template::<MAX_VALIDATOR_SET_SIZE, NB_MAP_JOBS, BATCH_SIZE>(
@@ -212,13 +212,13 @@ mod tests {
         const NB_MAP_JOBS: usize = 8;
         const BATCH_SIZE: usize = 32;
 
-        let start_block = 10000u64;
+        let start_block = 500u64;
         let start_header_hash =
-            hex::decode_upper("A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D")
+            hex::decode_upper("A4580A5609BD420694FB4718645529AC654470489CD4D8BF144C5208EC08819F")
                 .unwrap();
-        let end_block = 10004u64;
+        let end_block = 504u64;
         let _ =
-            hex::decode_upper("FCDA37FA6306C77737DD911E6101B612E2DBD837F29ED4F4E1C30919FBAC9D05")
+            hex::decode_upper("D6DA719AE76440DD977D6D7E618F71BEF4239D7C5D24A2B7588DFA6227B1EB38")
                 .unwrap();
 
         test_header_range_template::<MAX_VALIDATOR_SET_SIZE, NB_MAP_JOBS, BATCH_SIZE>(

--- a/circuits/input.rs
+++ b/circuits/input.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use async_trait::async_trait;
 use ethers::types::H256;
-use log::{debug, info};
+use log::info;
 use plonky2x::frontend::merkle::tree::InclusionProof;
 use plonky2x::prelude::RichField;
 use serde::Deserialize;

--- a/circuits/input.rs
+++ b/circuits/input.rs
@@ -109,8 +109,8 @@ impl DataCommitmentInputs for InputDataFetcher {
         for i in start_block_number..end_block_number + 1 {
             let header = self.get_header_from_number(i).await;
 
-            // Don't includce the data hash and corresponding proof of end, as data_commitment does
-            // not include it.
+            // Don't include the data hash and corresponding proof of end_block, as the circuit's
+            // data_commitment is computed over the range [start_block, end_block - 1].
             if i < end_block_number {
                 let data_hash = header.data_hash.unwrap();
                 data_hashes.push(data_hash.as_bytes().try_into().unwrap());
@@ -123,7 +123,10 @@ impl DataCommitmentInputs for InputDataFetcher {
                 data_hash_proofs.push(data_hash_proof);
             }
 
-            // Don't include last_block_id of start, as data_commitment does not include it.
+            // Don't include last_block_id of start, as the data_commitment circuit only requires
+            // the last block id's of blocks in the range [start_block + 1, end_block]. Specifically,
+            // the circuit needs the last_block_id proofs of data_commitment range shifted by one
+            // block to the right.
             if i > start_block_number {
                 let last_block_id_proof = self
                     .get_inclusion_proof::<PROTOBUF_BLOCK_ID_SIZE_BYTES, F>(

--- a/circuits/input.rs
+++ b/circuits/input.rs
@@ -115,8 +115,6 @@ impl DataCommitmentInputs for InputDataFetcher {
                 let data_hash = header.data_hash.unwrap();
                 data_hashes.push(data_hash.as_bytes().try_into().unwrap());
 
-                debug!("data_hash: {:?}", data_hash.as_bytes());
-
                 let data_hash_proof = self.get_inclusion_proof::<PROTOBUF_HASH_SIZE_BYTES, F>(
                     &header,
                     DATA_HASH_INDEX as u64,
@@ -127,10 +125,6 @@ impl DataCommitmentInputs for InputDataFetcher {
 
             // Don't include last_block_id of start, as data_commitment does not include it.
             if i > start_block_number {
-                debug!(
-                    "last block id: {:?}",
-                    Protobuf::<RawBlockId>::encode_vec(header.last_block_id.unwrap_or_default())
-                );
                 let last_block_id_proof = self
                     .get_inclusion_proof::<PROTOBUF_BLOCK_ID_SIZE_BYTES, F>(
                         &header,

--- a/circuits/next_header.rs
+++ b/circuits/next_header.rs
@@ -125,9 +125,9 @@ mod tests {
     fn test_next_header_small() {
         const MAX_VALIDATOR_SET_SIZE: usize = 4;
 
-        let start_block = 10000u64;
+        let start_block = 500u64;
         let start_header_hash =
-            hex::decode_upper("A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D")
+            hex::decode_upper("A4580A5609BD420694FB4718645529AC654470489CD4D8BF144C5208EC08819F")
                 .unwrap();
 
         test_next_header_template::<MAX_VALIDATOR_SET_SIZE>(
@@ -141,9 +141,9 @@ mod tests {
     fn test_next_header_large() {
         const MAX_VALIDATOR_SET_SIZE: usize = 100;
 
-        let start_block = 10000u64;
+        let start_block = 500u64;
         let start_header_hash =
-            hex::decode_upper("A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D")
+            hex::decode_upper("A4580A5609BD420694FB4718645529AC654470489CD4D8BF144C5208EC08819F")
                 .unwrap();
 
         test_next_header_template::<MAX_VALIDATOR_SET_SIZE>(
@@ -157,9 +157,9 @@ mod tests {
     fn test_next_header_medium() {
         const MAX_VALIDATOR_SET_SIZE: usize = 32;
 
-        let start_block = 10000u64;
+        let start_block = 500u64;
         let start_header_hash =
-            hex::decode_upper("A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D")
+            hex::decode_upper("A4580A5609BD420694FB4718645529AC654470489CD4D8BF144C5208EC08819F")
                 .unwrap();
 
         test_next_header_template::<MAX_VALIDATOR_SET_SIZE>(

--- a/contracts/script/BlobstreamX.s.sol
+++ b/contracts/script/BlobstreamX.s.sol
@@ -12,37 +12,30 @@ contract DeployScript is Script {
     function run() public {
         vm.startBroadcast();
         // Note: Update gateway when deployed.
-        address gateway = address(0xE304f6B116bE5e43424cEC36a5eFd0B642E0dC95);
+        address gateway = address(0x6e4f1e9eA315EBFd69d18C2DB974EEf6105FB803);
         // next_header_32
         bytes32 nextHeaderFunctionId = bytes32(
-            0xde939452e6506cc08d1d7b32ffe1b82cf9d96829b7aa30f0b542f1050651c43c
+            0x447a6e2becb9182a969a946b7e979a5707c546c6bed9d944fec2080ed9d48fac
         );
         // header_range_32
         bytes32 headerRangeFunctionId = bytes32(
-            0x6e6d644f9af0228e739c594f889a49f13283043e7f7c0a55379ca212ad0b4609
+            0x59bbb022181c1e6c34aa34d48e393aa0910513f67da981e25787a4bde2bfb1df
         );
 
         // Use the below to interact with an already deployed Blobstream
         BlobstreamX blobstream = BlobstreamX(
-            0x67EA962864cdad3f2202118dc6f65Ff510F7BB4D
+            0x046120E6c6C48C05627FB369756F5f44858950a5
         );
 
         // Update gateway to new address.
         blobstream.updateGateway(gateway);
 
         // TODO: Add back in when testing a new skip or step.
-        uint64 height = 10000;
-        bytes32 header = hex"A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D";
+        uint64 height = 1;
+        bytes32 header = hex"6be39efd10ba412a9db5288488303f5dd32cf386707a5bef33617f4c43301872";
         blobstream.setGenesisHeader(height, header);
-
-        // uint64 height = 100100;
 
         blobstream.updateNextHeaderId(nextHeaderFunctionId);
         blobstream.updateHeaderRangeId(headerRangeFunctionId);
-
-        uint64 skipHeight = 10100;
-        blobstream.requestHeaderRange{value: 0.1 ether}(skipHeight);
-
-        // blobstream.requestNextHeader{value: 0.1 ether}(height);
     }
 }

--- a/contracts/script/BlobstreamX.s.sol
+++ b/contracts/script/BlobstreamX.s.sol
@@ -15,11 +15,11 @@ contract DeployScript is Script {
         address gateway = address(0x6e4f1e9eA315EBFd69d18C2DB974EEf6105FB803);
         // next_header_32
         bytes32 nextHeaderFunctionId = bytes32(
-            0x447a6e2becb9182a969a946b7e979a5707c546c6bed9d944fec2080ed9d48fac
+            0x24b8f995376d0ef0ddbe13514223d40d7ee2600f5146c91b5fab90ac09a7e6c9
         );
         // header_range_32
         bytes32 headerRangeFunctionId = bytes32(
-            0x59bbb022181c1e6c34aa34d48e393aa0910513f67da981e25787a4bde2bfb1df
+            0xd763b045b1eebfd6799c816e06a1fcf2d519fc3dabea13ae9904fcab357de67e
         );
 
         // Use the below to interact with an already deployed Blobstream
@@ -30,7 +30,6 @@ contract DeployScript is Script {
         // Update gateway to new address.
         blobstream.updateGateway(gateway);
 
-        // TODO: Add back in when testing a new skip or step.
         uint64 height = 1;
         bytes32 header = hex"6be39efd10ba412a9db5288488303f5dd32cf386707a5bef33617f4c43301872";
         blobstream.setGenesisHeader(height, header);

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -11,16 +11,7 @@ contract DeployScript is Script {
 
     function run() public {
         vm.startBroadcast();
-        // Note: Update gateway when deployed.
         address gateway = address(0x6e4f1e9eA315EBFd69d18C2DB974EEf6105FB803);
-        // next_header_32
-        bytes32 nextHeaderFunctionId = bytes32(
-            0x24b8f995376d0ef0ddbe13514223d40d7ee2600f5146c91b5fab90ac09a7e6c9
-        );
-        // header_range_32
-        bytes32 headerRangeFunctionId = bytes32(
-            0xd763b045b1eebfd6799c816e06a1fcf2d519fc3dabea13ae9904fcab357de67e
-        );
 
         // Use the below to interact with an already deployed Blobstream
         BlobstreamX blobstream = BlobstreamX(
@@ -33,8 +24,5 @@ contract DeployScript is Script {
         uint64 height = 1;
         bytes32 header = hex"6be39efd10ba412a9db5288488303f5dd32cf386707a5bef33617f4c43301872";
         blobstream.setGenesisHeader(height, header);
-
-        blobstream.updateNextHeaderId(nextHeaderFunctionId);
-        blobstream.updateHeaderRangeId(headerRangeFunctionId);
     }
 }

--- a/contracts/script/FunctionID.s.sol
+++ b/contracts/script/FunctionID.s.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.22;
+
+import "forge-std/Script.sol";
+import {BlobstreamX} from "../src/BlobstreamX.sol";
+
+// forge script script/BlobstreamX.s.sol --verifier etherscan --private-key
+// forge verify-contract <address> BlobstreamX --chain 5 --etherscan-api-key ${ETHERSCAN_API_KEY} --constructor-args "0x000000000000000000000000852a94f8309d445d27222edb1e92a4e83dddd2a8"
+contract DeployScript is Script {
+    function setUp() public {}
+
+    function run() public {
+        vm.startBroadcast();
+        bytes32 nextHeaderFunctionId = bytes32(
+            0x24b8f995376d0ef0ddbe13514223d40d7ee2600f5146c91b5fab90ac09a7e6c9
+        );
+        bytes32 headerRangeFunctionId = bytes32(
+            0xd763b045b1eebfd6799c816e06a1fcf2d519fc3dabea13ae9904fcab357de67e
+        );
+
+        // Use the below to interact with an already deployed Blobstream
+        BlobstreamX blobstream = BlobstreamX(
+            0x046120E6c6C48C05627FB369756F5f44858950a5
+        );
+
+        blobstream.updateNextHeaderId(nextHeaderFunctionId);
+        blobstream.updateHeaderRangeId(headerRangeFunctionId);
+    }
+}


### PR DESCRIPTION
- Data commitment inputs no longer retrieve the last block id proof of the start block in the range. This caused an issue when we were fetching the last block id proof of the genesis header (which is a default value, causing an error when parsing it as input to the circuit).
- Update test cases to use headers from Celestia mainnet.
- Update ABI for `BlobstreamX`