### PR TITLE
fix: Updated broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Blobstream X
-Implementation of zero-knowledge proof circuits for [Blobstream](https://docs.celestia.org/nodes/blobstream-intro/), Celestia's data availability solution for Ethereum.
+Implementation of zero-knowledge proof circuits for [Blobstream](https://blog.celestia.org/introducing-blobstream/), Celestia's data availability solution for Ethereum.
 
 ## Overview
 Blobstream X's core contract is `BlobstreamX`, which stores commitments to ranges of data roots from Celestia blocks. Users can query for the validity of a data root of a specific block height via `verifyAttestation`, which proves that the data root is a leaf in the Merkle tree for the block range the specific block height is in.


### PR DESCRIPTION
The link to the documentation in the README.md file was broken. This commit updates the URL to the correct location.

replaced link intoduced succinct.xyz, I think this doc is suitable put in Readme
> [Succinct Labs](https://www.succinct.xyz/) has been developing an implementation of Blobstream that uses zero-knowledge proofs to verify Celestia’s validator EdDSA signatures on Ethereum. Blobstream X is also live today on [testnet](https://goerli.etherscan.io/address/0x67ea962864cdad3f2202118dc6f65ff510f7bb4d) (Goerli) and has several exciting benefits: