### PR TITLE
feat: local relay script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,15 +645,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "41daef31d7a747c5c847246f36de49ced6f7403b4cdabc807a97b5cc184cda7a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -2699,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.62"
+version = "0.10.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
+checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
@@ -2731,9 +2731,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.98"
+version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",
@@ -3061,7 +3061,7 @@ source = "git+https://github.com/mir-protocol/plonky2.git?rev=2d36559d#2d36559da
 [[package]]
 name = "plonky2x"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/succinctx.git#c4cc0d954d353c9c4e61b736dc968490d1146d71"
+source = "git+https://github.com/succinctlabs/succinctx.git#102fe9077c2b0fe485e27f30c267b1d9989cbc98"
 dependencies = [
  "anyhow",
  "array-macro",
@@ -3097,13 +3097,13 @@ dependencies = [
  "sha256",
  "tokio",
  "tracing",
- "uuid 1.6.1",
+ "uuid 1.7.0",
 ]
 
 [[package]]
 name = "plonky2x-derive"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/succinctx.git#c4cc0d954d353c9c4e61b736dc968490d1146d71"
+source = "git+https://github.com/succinctlabs/succinctx.git#102fe9077c2b0fe485e27f30c267b1d9989cbc98"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3216,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -3377,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3389,9 +3389,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3889,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+checksum = "f58c3a1b3e418f61c25b2aeb43fc6c95eaa252b8cecdda67f401943e9e08d33f"
 dependencies = [
  "base64 0.21.7",
  "chrono",
@@ -3906,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+checksum = "d2068b437a31fc68f25dd7edc296b078f04b45145c199d8eed9866e45f1ff274"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4031,9 +4031,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b187f0231d56fe41bfb12034819dd2bf336422a5866de41bc3fec4b2e3883e8"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
@@ -4152,7 +4152,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "succinct-client"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/succinctx.git#c4cc0d954d353c9c4e61b736dc968490d1146d71"
+source = "git+https://github.com/succinctlabs/succinctx.git#102fe9077c2b0fe485e27f30c267b1d9989cbc98"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4163,7 +4163,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
- "uuid 1.6.1",
+ "uuid 1.7.0",
 ]
 
 [[package]]
@@ -4791,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 path = "circuits/lib.rs"
 
 [[bin]]
+name = "local_relay"
+path = "bin/local_relay.rs"
+
+[[bin]]
 name = "next_header"
 path = "bin/next_header.rs"
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,35 @@
 # Blobstream X
+
 ![Blobstream X](https://pbs.twimg.com/media/F85boT-bYAAF1hM?format=jpg&name=4096x4096)
 
 Implementation of zero-knowledge proof circuits for [Blobstream](https://docs.celestia.org/developers/blobstream), Celestia's data availability solution for Ethereum.
 
 ## Overview
+
 Blobstream X's core contract is `BlobstreamX`, which stores commitments to ranges of data roots from Celestia blocks. Users can query for the validity of a data root of a specific block height via `verifyAttestation`, which proves that the data root is a leaf in the Merkle tree for the block range the specific block height is in.
 
 ### headerRange
-`headerRange` is used to generate the data root of a block range. The data root is the root of a Merkle tree of the data roots of all the blocks in the block range. 
+
+`headerRange` is used to generate the data root of a block range. The data root is the root of a Merkle tree of the data roots of all the blocks in the block range.
 
 To prove the last header of a block range, `headerRange` uses `skip` as a sub-circuit. After proving the last header, the `headerRange` circuit proves the chain of headers from the start header to the last header. From a valid chain of headers, the `headerRange` circuit can generate the commitment of the block range with the data root of each block in the block range.
 
 ### nextHeader
+
 `nextHeader` is used to generate the commitment to the data root of the current block.
 
 This is rarely used, as `nextHeader` will only be invoked when the validator set changes by more than 2/3 in a single block.
 
-
 ## Deployment
+
 The circuits are currently available on Succinct X [here](https://alpha.succinct.xyz/celestia/blobstreamx/releases).
 
 Blobstream X is currently deployed for Celestia Mainnet on Goerli [here](https://goerli.etherscan.io/address/0x046120E6c6C48C05627FB369756F5f44858950a5#events).
 
 ## Integrate
+
 Get the genesis parameters for the `BlobstreamX` contract with a specific Celestia block (with no input defaults to block 1).
+
 ```
 cargo run --bin genesis -- --block 100
 ```
@@ -33,6 +39,7 @@ Add .env variables to `contracts/.env`, following `contracts/.env.example`.
 Initialize `BlobstreamX` contract with genesis parameters.
 
 In `contracts/`, run
+
 ```
 forge install
 
@@ -46,12 +53,15 @@ Add env variables to `.env`, following `.env.example`.
 Run `BlobstreamX` script to update the light client continuously.
 
 In `/`, run
+
 ```
 cargo run --bin blobstreamx --release
 ```
 
 ## Local Proving & Relaying
+
 To enable local proving & local relaying of proofs, simply add the following to your `.env`:
+
 ```
 LOCAL_PROVE_MODE=true
 LOCAL_RELAY_MODE=true
@@ -62,3 +72,10 @@ PROVE_BINARY_0xFILL_IN_HEADER_RANGE_FUNCTION_ID=
 WRAPPER_BINARY=
 ```
 
+### Relay an Existing Proof
+
+If you want to relay an existing proof in `/proofs`, run the following command:
+
+```
+cargo run --bin local_relay --release -- --request-id {REQUEST_ID}
+```

--- a/bin/local_relay.rs
+++ b/bin/local_relay.rs
@@ -1,0 +1,90 @@
+// Relay local proof
+
+use std::env;
+use std::str::FromStr;
+
+use clap::Parser;
+use ethers::contract::abigen;
+use ethers::signers::LocalWallet;
+use log::info;
+use succinct_client::request::SuccinctClient;
+
+// Note: Update ABI when updating contract.
+abigen!(BlobstreamX, "./abi/BlobstreamX.abi.json");
+
+struct BlobstreamXRelayer {
+    client: SuccinctClient,
+    ethereum_rpc_url: String,
+    wallet: LocalWallet,
+}
+
+impl BlobstreamXRelayer {
+    pub fn new() -> Self {
+        let ethereum_rpc_url = env::var("RPC_URL").expect("RPC_URL must be set");
+        let private_key =
+            env::var("PRIVATE_KEY").unwrap_or(String::from("0x00000000000000000000000000000000"));
+        let wallet = LocalWallet::from_str(&private_key).expect("invalid private key");
+
+        let succinct_rpc_url = env::var("SUCCINCT_RPC_URL").expect("SUCCINCT_RPC_URL must be set");
+        let succinct_api_key = env::var("SUCCINCT_API_KEY").expect("SUCCINCT_API_KEY must be set");
+
+        // Local prove mode and local relay mode are optional and default to false.
+        let local_prove_mode: String =
+            env::var("LOCAL_PROVE_MODE").unwrap_or(String::from("false"));
+        let local_prove_mode_bool = local_prove_mode.parse::<bool>().unwrap();
+        let local_relay_mode: String =
+            env::var("LOCAL_RELAY_MODE").unwrap_or(String::from("false"));
+        let local_relay_mode_bool = local_relay_mode.parse::<bool>().unwrap();
+
+        let client = SuccinctClient::new(
+            succinct_rpc_url,
+            succinct_api_key,
+            local_prove_mode_bool,
+            local_relay_mode_bool,
+        );
+
+        Self {
+            client,
+            ethereum_rpc_url,
+            wallet,
+        }
+    }
+
+    async fn run(&self, request_id: String) {
+        info!("Starting BlobstreamX relayer");
+
+        // If in local mode, this will submit the request on-chain.
+        let res = self
+            .client
+            .relay_proof(
+                request_id,
+                Some(self.ethereum_rpc_url.as_ref()),
+                Some(self.wallet.clone()),
+                None,
+            )
+            .await;
+        info!("Relay result: {:?}", res);
+    }
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(about = "Get the request ID.")]
+pub struct LocalRelayArgs {
+    #[arg(long)]
+    pub request_id: String,
+}
+
+#[tokio::main]
+async fn main() {
+    env::set_var("RUST_LOG", "debug");
+    dotenv::dotenv().ok();
+    env_logger::init();
+
+    let operator = BlobstreamXRelayer::new();
+
+    // Read the request ID from the command line.
+    let args = LocalRelayArgs::parse();
+    let request_id = args.request_id;
+
+    operator.run(request_id).await;
+}

--- a/contracts/.env.example
+++ b/contracts/.env.example
@@ -1,6 +1,6 @@
 # Ethereum config
 PRIVATE_KEY=
-ETHEREUM_RPC_URL=
+RPC_URL=
 ETHERSCAN_API_KEY=
 
 # Note: Use random bytes to create deterministic addresses (ex. 0xaa)


### PR DESCRIPTION
Relay existing proofs in the `/proofs` directory with `cargo run --bin local_relay -- --request-id {REQUEST_ID}`.