### PR TITLE
refactor: fix `commitHeaderRange`

### DIFF
--- a/abi/BlobstreamX.abi.json
+++ b/abi/BlobstreamX.abi.json
@@ -1,853 +1,852 @@
 [
     {
-        "inputs": [],
-        "name": "DataCommitmentNotFound",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "LatestHeaderNotFound",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            }
-        ],
-        "name": "OnlyGuardian",
-        "type": "error"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            }
-        ],
-        "name": "OnlyTimelock",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "ProofBlockRangeTooLarge",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "TargetBlockNotInRange",
-        "type": "error"
-    },
-    {
-        "inputs": [],
-        "name": "TrustedHeaderNotFound",
-        "type": "error"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "previousAdmin",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "newAdmin",
-                "type": "address"
-            }
-        ],
-        "name": "AdminChanged",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "beacon",
-                "type": "address"
-            }
-        ],
-        "name": "BeaconUpgraded",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "proofNonce",
-                "type": "uint256"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint64",
-                "name": "startBlock",
-                "type": "uint64"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint64",
-                "name": "endBlock",
-                "type": "uint64"
-            },
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "dataCommitment",
-                "type": "bytes32"
-            }
-        ],
-        "name": "DataCommitmentStored",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "uint64",
-                "name": "blockNumber",
-                "type": "uint64"
-            },
-            {
-                "indexed": false,
-                "internalType": "bytes32",
-                "name": "headerHash",
-                "type": "bytes32"
-            }
-        ],
-        "name": "HeadUpdate",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "uint64",
-                "name": "trustedBlock",
-                "type": "uint64"
-            },
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "trustedHeader",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint64",
-                "name": "targetBlock",
-                "type": "uint64"
-            }
-        ],
-        "name": "HeaderRangeRequested",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "uint8",
-                "name": "version",
-                "type": "uint8"
-            }
-        ],
-        "name": "Initialized",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "uint64",
-                "name": "trustedBlock",
-                "type": "uint64"
-            },
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "trustedHeader",
-                "type": "bytes32"
-            }
-        ],
-        "name": "NextHeaderRequested",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "previousAdminRole",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "newAdminRole",
-                "type": "bytes32"
-            }
-        ],
-        "name": "RoleAdminChanged",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            }
-        ],
-        "name": "RoleGranted",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            }
-        ],
-        "name": "RoleRevoked",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "uint64",
-                "name": "trustedBlock",
-                "type": "uint64"
-            },
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "trustedHeader",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint64",
-                "name": "targetBlock",
-                "type": "uint64"
-            }
-        ],
-        "name": "SkipRequested",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "uint64",
-                "name": "trustedBlock",
-                "type": "uint64"
-            },
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "trustedHeader",
-                "type": "bytes32"
-            }
-        ],
-        "name": "StepRequested",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "implementation",
-                "type": "address"
-            }
-        ],
-        "name": "Upgraded",
-        "type": "event"
-    },
-    {
-        "inputs": [],
+        "type": "function",
         "name": "DATA_COMMITMENT_MAX",
+        "inputs": [],
         "outputs": [
             {
-                "internalType": "uint64",
                 "name": "",
-                "type": "uint64"
+                "type": "uint64",
+                "internalType": "uint64"
             }
         ],
-        "stateMutability": "view",
-        "type": "function"
+        "stateMutability": "view"
     },
     {
-        "inputs": [],
+        "type": "function",
         "name": "DEFAULT_ADMIN_ROLE",
+        "inputs": [],
         "outputs": [
             {
-                "internalType": "bytes32",
                 "name": "",
-                "type": "bytes32"
+                "type": "bytes32",
+                "internalType": "bytes32"
             }
         ],
-        "stateMutability": "view",
-        "type": "function"
+        "stateMutability": "view"
     },
     {
-        "inputs": [],
+        "type": "function",
         "name": "GUARDIAN_ROLE",
+        "inputs": [],
         "outputs": [
             {
-                "internalType": "bytes32",
                 "name": "",
-                "type": "bytes32"
+                "type": "bytes32",
+                "internalType": "bytes32"
             }
         ],
-        "stateMutability": "view",
-        "type": "function"
+        "stateMutability": "view"
     },
     {
-        "inputs": [],
+        "type": "function",
         "name": "TIMELOCK_ROLE",
+        "inputs": [],
         "outputs": [
             {
-                "internalType": "bytes32",
                 "name": "",
-                "type": "bytes32"
+                "type": "bytes32",
+                "internalType": "bytes32"
             }
         ],
-        "stateMutability": "view",
-        "type": "function"
+        "stateMutability": "view"
     },
     {
-        "inputs": [],
+        "type": "function",
         "name": "VERSION",
+        "inputs": [],
         "outputs": [
             {
-                "internalType": "string",
                 "name": "",
-                "type": "string"
+                "type": "string",
+                "internalType": "string"
             }
         ],
-        "stateMutability": "pure",
-        "type": "function"
+        "stateMutability": "pure"
     },
     {
-        "inputs": [
-            {
-                "internalType": "uint64",
-                "name": "",
-                "type": "uint64"
-            }
-        ],
+        "type": "function",
         "name": "blockHeightToHeaderHash",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
         "inputs": [
             {
-                "internalType": "uint64",
-                "name": "_trustedBlock",
-                "type": "uint64"
-            },
-            {
-                "internalType": "uint64",
-                "name": "_targetBlock",
-                "type": "uint64"
+                "name": "",
+                "type": "uint64",
+                "internalType": "uint64"
             }
         ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
         "name": "commitHeaderRange",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
         "inputs": [
             {
-                "internalType": "uint64",
-                "name": "_trustedBlock",
-                "type": "uint64"
-            }
-        ],
-        "name": "commitNextHeader",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "gateway",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint64",
-                "name": "_height",
-                "type": "uint64"
-            }
-        ],
-        "name": "getHeaderHash",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            }
-        ],
-        "name": "getRoleAdmin",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "grantRole",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "hasRole",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "headerRangeFunctionId",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_guardian",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_gateway",
-                "type": "address"
-            },
-            {
-                "internalType": "uint64",
-                "name": "_height",
-                "type": "uint64"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "_header",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "_nextHeaderFunctionId",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "_headerRangeFunctionId",
-                "type": "bytes32"
-            }
-        ],
-        "name": "initialize",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "latestBlock",
-        "outputs": [
-            {
-                "internalType": "uint64",
-                "name": "",
-                "type": "uint64"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "nextHeaderFunctionId",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "proxiableUUID",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "renounceRole",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint64",
                 "name": "_targetBlock",
-                "type": "uint64"
+                "type": "uint64",
+                "internalType": "uint64"
             }
         ],
-        "name": "requestHeaderRange",
         "outputs": [],
-        "stateMutability": "payable",
-        "type": "function"
+        "stateMutability": "nonpayable"
     },
     {
-        "inputs": [],
-        "name": "requestNextHeader",
-        "outputs": [],
-        "stateMutability": "payable",
-        "type": "function"
-    },
-    {
+        "type": "function",
+        "name": "commitNextHeader",
         "inputs": [
             {
-                "internalType": "bytes32",
+                "name": "_trustedBlock",
+                "type": "uint64",
+                "internalType": "uint64"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "frozen",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "gateway",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getHeaderHash",
+        "inputs": [
+            {
+                "name": "_height",
+                "type": "uint64",
+                "internalType": "uint64"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "getRoleAdmin",
+        "inputs": [
+            {
                 "name": "role",
-                "type": "bytes32"
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "grantRole",
+        "inputs": [
+            {
+                "name": "role",
+                "type": "bytes32",
+                "internalType": "bytes32"
             },
             {
-                "internalType": "address",
                 "name": "account",
-                "type": "address"
+                "type": "address",
+                "internalType": "address"
             }
         ],
-        "name": "revokeRole",
         "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+        "stateMutability": "nonpayable"
     },
     {
+        "type": "function",
+        "name": "hasRole",
         "inputs": [
             {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
+                "name": "role",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
             }
         ],
-        "name": "state_dataCommitments",
         "outputs": [
             {
-                "internalType": "bytes32",
                 "name": "",
-                "type": "bytes32"
+                "type": "bool",
+                "internalType": "bool"
             }
         ],
-        "stateMutability": "view",
-        "type": "function"
+        "stateMutability": "view"
     },
     {
+        "type": "function",
+        "name": "headerRangeFunctionId",
         "inputs": [],
-        "name": "state_proofNonce",
         "outputs": [
             {
-                "internalType": "uint256",
                 "name": "",
-                "type": "uint256"
+                "type": "bytes32",
+                "internalType": "bytes32"
             }
         ],
-        "stateMutability": "view",
-        "type": "function"
+        "stateMutability": "view"
     },
     {
+        "type": "function",
+        "name": "initialize",
         "inputs": [
             {
-                "internalType": "bytes4",
-                "name": "interfaceId",
-                "type": "bytes4"
-            }
-        ],
-        "name": "supportsInterface",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_gateway",
-                "type": "address"
-            }
-        ],
-        "name": "updateGateway",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "_functionId",
-                "type": "bytes32"
-            }
-        ],
-        "name": "updateHeaderRangeId",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "_functionId",
-                "type": "bytes32"
-            }
-        ],
-        "name": "updateNextHeaderId",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newImplementation",
-                "type": "address"
-            }
-        ],
-        "name": "upgradeTo",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newImplementation",
-                "type": "address"
-            },
-            {
-                "internalType": "bytes",
-                "name": "data",
-                "type": "bytes"
-            }
-        ],
-        "name": "upgradeToAndCall",
-        "outputs": [],
-        "stateMutability": "payable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_proofNonce",
-                "type": "uint256"
-            },
-            {
+                "name": "_params",
+                "type": "tuple",
+                "internalType": "struct BlobstreamX.InitParameters",
                 "components": [
                     {
-                        "internalType": "uint256",
+                        "name": "guardian",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "gateway",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
                         "name": "height",
-                        "type": "uint256"
+                        "type": "uint64",
+                        "internalType": "uint64"
                     },
                     {
-                        "internalType": "bytes32",
-                        "name": "dataRoot",
-                        "type": "bytes32"
+                        "name": "header",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "nextHeaderFunctionId",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    },
+                    {
+                        "name": "headerRangeFunctionId",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
                     }
-                ],
-                "internalType": "struct DataRootTuple",
-                "name": "_tuple",
-                "type": "tuple"
-            },
-            {
-                "components": [
-                    {
-                        "internalType": "bytes32[]",
-                        "name": "sideNodes",
-                        "type": "bytes32[]"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "key",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "numLeaves",
-                        "type": "uint256"
-                    }
-                ],
-                "internalType": "struct BinaryMerkleProof",
-                "name": "_proof",
-                "type": "tuple"
+                ]
             }
         ],
-        "name": "verifyAttestation",
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "latestBlock",
+        "inputs": [],
         "outputs": [
             {
-                "internalType": "bool",
                 "name": "",
-                "type": "bool"
+                "type": "uint64",
+                "internalType": "uint64"
             }
         ],
-        "stateMutability": "view",
-        "type": "function"
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "nextHeaderFunctionId",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "proxiableUUID",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "renounceRole",
+        "inputs": [
+            {
+                "name": "role",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "requestHeaderRange",
+        "inputs": [
+            {
+                "name": "_targetBlock",
+                "type": "uint64",
+                "internalType": "uint64"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "requestNextHeader",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "revokeRole",
+        "inputs": [
+            {
+                "name": "role",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "state_dataCommitments",
+        "inputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "state_proofNonce",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "supportsInterface",
+        "inputs": [
+            {
+                "name": "interfaceId",
+                "type": "bytes4",
+                "internalType": "bytes4"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "updateFreeze",
+        "inputs": [
+            {
+                "name": "_freeze",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "updateFunctionIds",
+        "inputs": [
+            {
+                "name": "_headerRangeFunctionId",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "_nextHeaderFunctionId",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "updateGateway",
+        "inputs": [
+            {
+                "name": "_gateway",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "updateGenesisState",
+        "inputs": [
+            {
+                "name": "_height",
+                "type": "uint32",
+                "internalType": "uint32"
+            },
+            {
+                "name": "_header",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "upgradeTo",
+        "inputs": [
+            {
+                "name": "newImplementation",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "upgradeToAndCall",
+        "inputs": [
+            {
+                "name": "newImplementation",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "data",
+                "type": "bytes",
+                "internalType": "bytes"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "name": "verifyAttestation",
+        "inputs": [
+            {
+                "name": "_proofNonce",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "_tuple",
+                "type": "tuple",
+                "internalType": "struct DataRootTuple",
+                "components": [
+                    {
+                        "name": "height",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "dataRoot",
+                        "type": "bytes32",
+                        "internalType": "bytes32"
+                    }
+                ]
+            },
+            {
+                "name": "_proof",
+                "type": "tuple",
+                "internalType": "struct BinaryMerkleProof",
+                "components": [
+                    {
+                        "name": "sideNodes",
+                        "type": "bytes32[]",
+                        "internalType": "bytes32[]"
+                    },
+                    {
+                        "name": "key",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "numLeaves",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    }
+                ]
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "event",
+        "name": "AdminChanged",
+        "inputs": [
+            {
+                "name": "previousAdmin",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            },
+            {
+                "name": "newAdmin",
+                "type": "address",
+                "indexed": false,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "BeaconUpgraded",
+        "inputs": [
+            {
+                "name": "beacon",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "DataCommitmentStored",
+        "inputs": [
+            {
+                "name": "proofNonce",
+                "type": "uint256",
+                "indexed": false,
+                "internalType": "uint256"
+            },
+            {
+                "name": "startBlock",
+                "type": "uint64",
+                "indexed": true,
+                "internalType": "uint64"
+            },
+            {
+                "name": "endBlock",
+                "type": "uint64",
+                "indexed": true,
+                "internalType": "uint64"
+            },
+            {
+                "name": "dataCommitment",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "HeadUpdate",
+        "inputs": [
+            {
+                "name": "blockNumber",
+                "type": "uint64",
+                "indexed": false,
+                "internalType": "uint64"
+            },
+            {
+                "name": "headerHash",
+                "type": "bytes32",
+                "indexed": false,
+                "internalType": "bytes32"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "HeaderRangeRequested",
+        "inputs": [
+            {
+                "name": "trustedBlock",
+                "type": "uint64",
+                "indexed": true,
+                "internalType": "uint64"
+            },
+            {
+                "name": "trustedHeader",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
+            },
+            {
+                "name": "targetBlock",
+                "type": "uint64",
+                "indexed": true,
+                "internalType": "uint64"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Initialized",
+        "inputs": [
+            {
+                "name": "version",
+                "type": "uint8",
+                "indexed": false,
+                "internalType": "uint8"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "NextHeaderRequested",
+        "inputs": [
+            {
+                "name": "trustedBlock",
+                "type": "uint64",
+                "indexed": true,
+                "internalType": "uint64"
+            },
+            {
+                "name": "trustedHeader",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "RoleAdminChanged",
+        "inputs": [
+            {
+                "name": "role",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
+            },
+            {
+                "name": "previousAdminRole",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
+            },
+            {
+                "name": "newAdminRole",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "RoleGranted",
+        "inputs": [
+            {
+                "name": "role",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
+            },
+            {
+                "name": "account",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "sender",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "RoleRevoked",
+        "inputs": [
+            {
+                "name": "role",
+                "type": "bytes32",
+                "indexed": true,
+                "internalType": "bytes32"
+            },
+            {
+                "name": "account",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "sender",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "Upgraded",
+        "inputs": [
+            {
+                "name": "implementation",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "error",
+        "name": "ContractFrozen",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "DataCommitmentNotFound",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "LatestHeaderNotFound",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "OnlyGuardian",
+        "inputs": [
+            {
+                "name": "sender",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "OnlyTimelock",
+        "inputs": [
+            {
+                "name": "sender",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "type": "error",
+        "name": "TargetBlockNotInRange",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "TrustedBlockMismatch",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "TrustedHeaderNotFound",
+        "inputs": []
     }
 ]

--- a/bin/blobstreamx.rs
+++ b/bin/blobstreamx.rs
@@ -169,10 +169,7 @@ impl BlobstreamXOperator {
             target_block,
         ));
 
-        let commit_header_range_call = CommitHeaderRangeCall {
-            trusted_block,
-            target_block,
-        };
+        let commit_header_range_call = CommitHeaderRangeCall { target_block };
         let function_data = commit_header_range_call.encode();
 
         let request_id = self

--- a/contracts/.env.example
+++ b/contracts/.env.example
@@ -6,6 +6,7 @@ ETHERSCAN_API_KEY=
 # Note: Use random bytes to create deterministic addresses (ex. 0xaa)
 CREATE2_SALT=
 
+GUARDIAN_ADDRESS=
 GATEWAY_ADDRESS=
 NEXT_HEADER_FUNCTION_ID=
 HEADER_RANGE_FUNCTION_ID=

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -8,6 +8,7 @@ Fill out the following fields in `.env` in `contracts` folder:
 - `RPC_URL` - URL of the Ethereum RPC node
 - `ETHERSCAN_API_KEY` - API key for Etherscan
 - `CREATE2_SALT` - Salt for CREATE2 deployment (determinstic deployment)
+- `GUARDIAN_ADDRESS` - Address of the guardian (multi-sig/Gnosis Safe).
 - `GATEWAY_ADDRESS` - Address of the gateway contract
 - `GENESIS_HEIGHT` - Height of the block at which the contract will be deployed
 - `GENESIS_HEADER` - Header of the block at which the contract will be deployed

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -11,6 +11,8 @@ Fill out the following fields in `.env` in `contracts` folder:
 - `GATEWAY_ADDRESS` - Address of the gateway contract
 - `GENESIS_HEIGHT` - Height of the block at which the contract will be deployed
 - `GENESIS_HEADER` - Header of the block at which the contract will be deployed
+- `NEXT_HEADER_FUNCTION_ID` - Function ID for `nextHeader` function
+- `HEADER_RANGE_FUNCTION_ID` - Function ID for `headerRange` function
 
 Then run the following command:
 

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -43,7 +43,6 @@ contract DeployScript is Script {
             // Initialize the Blobstream X light client.
             lightClient.initialize(
                 BlobstreamX.InitParameters({
-                    // TODO: Migrate to using upgrade scripts in SuccinctX that work with Gnosis Safe.
                     guardian: vm.envAddress("GUARDIAN_ADDRESS"),
                     gateway: gateway,
                     height: height,

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -44,7 +44,7 @@ contract DeployScript is Script {
             lightClient.initialize(
                 BlobstreamX.InitParameters({
                     // TODO: Migrate to using upgrade scripts in SuccinctX that work with Gnosis Safe.
-                    guardian: vm.envAddress("GUARDIAN_ADDRESS");,
+                    guardian: vm.envAddress("GUARDIAN_ADDRESS"),
                     gateway: gateway,
                     height: height,
                     header: header,

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -43,7 +43,8 @@ contract DeployScript is Script {
             // Initialize the Blobstream X light client.
             lightClient.initialize(
                 BlobstreamX.InitParameters({
-                    guardian: msg.sender,
+                    // TODO: Migrate to using upgrade scripts in SuccinctX that work with Gnosis Safe.
+                    guardian: vm.envAddress("GUARDIAN_ADDRESS");,
                     gateway: gateway,
                     height: height,
                     header: header,

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -53,25 +53,22 @@ contract DeployScript is Script {
                 })
             );
         } else {
-            bool updateGateway = vm.envBool("UPDATE_GATEWAY");
-            bool updateGenesisState = vm.envBool("UPDATE_GENESIS_STATE");
-            bool updateFunctionIds = vm.envBool("UPDATE_FUNCTION_IDS");
             address existingProxyAddress = vm.envAddress("CONTRACT_ADDRESS");
 
             lightClient = BlobstreamX(existingProxyAddress);
             lightClient.upgradeTo(address(lightClientImpl));
+        }
+        console.logAddress(address(lightClient));
 
-            if (updateGateway) {
-                lightClient.updateGateway(gateway);
-            }
-            if (updateGenesisState) {
-                lightClient.updateGenesisState(height, header);
-            }
-            if (updateFunctionIds) {
-                lightClient.updateFunctionIds(headerRangeFunctionId, nextHeaderFunctionId);
-            }
+        if (vm.envBool("UPDATE_GATEWAY")) {
+            lightClient.updateGateway(gateway);
+        }
+        if (vm.envBool("UPDATE_GENESIS_STATE")) {
+            lightClient.updateGenesisState(height, header);
+        }
+        if (vm.envBool("UPDATE_FUNCTION_IDS")) {
+            lightClient.updateFunctionIds(headerRangeFunctionId, nextHeaderFunctionId);
         }
 
-        console.logAddress(address(lightClient));
     }
 }

--- a/contracts/src/interfaces/IBlobstreamX.sol
+++ b/contracts/src/interfaces/IBlobstreamX.sol
@@ -21,6 +21,9 @@ interface IBlobstreamX {
     /// @notice Contract is frozen.
     error ContractFrozen();
 
+    /// @notice Trusted block mismatch.
+    error TrustedBlockMismatch();
+
     /// @notice Data commitment stored for the block range [startBlock, endBlock) with proof nonce.
     /// @param proofNonce The nonce of the proof.
     /// @param startBlock The start block of the block range.


### PR DESCRIPTION
`commitHeaderRange` should use the `latestBlock` as the `trustedBlock`. This guarantees that all data commitments are over exclusive ranges and are monotonically increasing.

Also, this PR re-generates the ABI bindings for the `BlobstreamX` contract.