### PR TITLE
fix(audit): constrain data hashes

### DIFF
--- a/circuits/builder.rs
+++ b/circuits/builder.rs
@@ -400,7 +400,7 @@ pub(crate) mod tests {
     use tokio::runtime::Runtime;
 
     use super::*;
-    use crate::input::DataCommitmentInputs;
+    use crate::input::DataCommitmentInputFetcher;
     use crate::vars::*;
 
     type L = DefaultParameters;
@@ -425,13 +425,13 @@ pub(crate) mod tests {
         (
             DataCommitmentProofValueType {
                 start_block_height: (start_height as u64),
-                start_header: H256::from_slice(&result.0),
+                start_header: H256::from_slice(&result.start_header_hash),
                 end_block_height: (end_height as u64),
-                end_header: H256::from_slice(&result.1),
-                data_hash_proofs: result.3,
-                last_block_id_proofs: result.4,
+                end_header: H256::from_slice(&result.end_header_hash),
+                data_hash_proofs: result.data_hash_proofs,
+                last_block_id_proofs: result.last_block_id_proofs,
             },
-            H256(result.5),
+            H256(result.expected_data_commitment),
         )
     }
 

--- a/circuits/builder.rs
+++ b/circuits/builder.rs
@@ -215,15 +215,21 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
             curr_block_enabled = self.and(curr_block_enabled, is_not_last_block);
         }
 
+        let data_hashes = ArrayVariable::<Bytes32Variable, BATCH_SIZE>::from(
+            data_comm_proof
+                .data_hash_proofs
+                .data
+                .iter()
+                .map(|proof| Bytes32Variable::from(&proof.leaf[2..2 + HASH_SIZE]))
+                .collect::<Vec<_>>(),
+        );
+
         // The end block of the batch's data_merkle_root is min(batch_end_block, global_end_block).
         // Compute the data_merkle_root for the batch.
         let is_less_than_target = self.lte(batch_end_block, *global_end_block);
         let end_block_num = self.select(is_less_than_target, batch_end_block, *global_end_block);
-        let data_merkle_root = self.get_data_commitment::<BATCH_SIZE>(
-            &data_comm_proof.data_hashes,
-            batch_start_block,
-            end_block_num,
-        );
+        let data_merkle_root =
+            self.get_data_commitment::<BATCH_SIZE>(&data_hashes, batch_start_block, end_block_num);
 
         MapReduceSubchainVariable {
             is_enabled: is_batch_enabled,
@@ -374,8 +380,10 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
             );
         self.assert_is_equal(data_hash_proof_root, prev_header_hash);
 
-        let encoded_tuple =
-            self.encode_data_root_tuple(&data_comm_proof.data_hashes[0], &prev_block_number);
+        let leaf =
+            Bytes32Variable::from(&data_comm_proof.data_hash_proofs.data[0].leaf[2..2 + HASH_SIZE]);
+
+        let encoded_tuple = self.encode_data_root_tuple(&leaf, &prev_block_number);
 
         // Return the data_commitment for the range (which only includes 1 block: prev_block_number).
         self.leaf_hash(&encoded_tuple.0)
@@ -388,7 +396,6 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
 pub(crate) mod tests {
     use ethers::types::H256;
     use plonky2x::backend::circuit::DefaultParameters;
-    use tendermintx::input::utils::convert_to_h256;
     use tendermintx::input::InputDataFetcher;
     use tokio::runtime::Runtime;
 
@@ -417,7 +424,6 @@ pub(crate) mod tests {
 
         (
             DataCommitmentProofValueType {
-                data_hashes: convert_to_h256(result.2),
                 start_block_height: (start_height as u64),
                 start_header: H256::from_slice(&result.0),
                 end_block_height: (end_height as u64),
@@ -447,11 +453,18 @@ pub(crate) mod tests {
 
         let start_block = builder.constant::<U64Variable>(START_BLOCK as u64);
         let end_block = builder.constant::<U64Variable>(END_BLOCK as u64);
-        let root_hash_target = builder.get_data_commitment::<MAX_LEAVES>(
-            &data_commitment_var.data_hashes,
-            start_block,
-            end_block,
+
+        let data_hashes = ArrayVariable::<Bytes32Variable, MAX_LEAVES>::from(
+            data_commitment_var
+                .data_hash_proofs
+                .data
+                .iter()
+                .map(|proof| Bytes32Variable::from(&proof.leaf[2..2 + HASH_SIZE]))
+                .collect::<Vec<_>>(),
         );
+
+        let root_hash_target =
+            builder.get_data_commitment::<MAX_LEAVES>(&data_hashes, start_block, end_block);
         builder.assert_is_equal(root_hash_target, expected_data_commitment);
 
         let circuit = builder.build();

--- a/circuits/data_commitment.rs
+++ b/circuits/data_commitment.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use tendermintx::input::InputDataFetcher;
 
 use crate::builder::{DataCommitmentBuilder, DataCommitmentSharedCtx};
-use crate::input::DataCommitmentInputs;
+use crate::input::DataCommitmentInputFetcher;
 use crate::vars::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,11 +35,11 @@ impl<const MAX_LEAVES: usize, L: PlonkParameters<D>, const D: usize> AsyncHint<L
 
         let data_comm_proof = DataCommitmentProofValueType {
             start_block_height: start_block,
-            start_header: H256(result.0),
+            start_header: H256(result.start_header_hash),
             end_block_height: end_block,
-            end_header: H256(result.1),
-            data_hash_proofs: result.3,
-            last_block_id_proofs: result.4,
+            end_header: H256(result.end_header_hash),
+            data_hash_proofs: result.data_hash_proofs,
+            last_block_id_proofs: result.last_block_id_proofs,
         };
         // Write the inputs to the data commitment circuit.
         output_stream.write_value::<DataCommitmentProofVariable<MAX_LEAVES>>(data_comm_proof);

--- a/circuits/data_commitment.rs
+++ b/circuits/data_commitment.rs
@@ -6,7 +6,6 @@ use plonky2x::frontend::mapreduce::generator::MapReduceGenerator;
 use plonky2x::frontend::uint::uint64::U64Variable;
 use plonky2x::prelude::{Bytes32Variable, CircuitBuilder, PlonkParameters, ValueStream};
 use serde::{Deserialize, Serialize};
-use tendermintx::input::utils::convert_to_h256;
 use tendermintx::input::InputDataFetcher;
 
 use crate::builder::{DataCommitmentBuilder, DataCommitmentSharedCtx};
@@ -35,7 +34,6 @@ impl<const MAX_LEAVES: usize, L: PlonkParameters<D>, const D: usize> AsyncHint<L
             .await;
 
         let data_comm_proof = DataCommitmentProofValueType {
-            data_hashes: convert_to_h256(result.2),
             start_block_height: start_block,
             start_header: H256(result.0),
             end_block_height: end_block,

--- a/circuits/input.rs
+++ b/circuits/input.rs
@@ -200,7 +200,7 @@ impl DataCommitmentInputFetcher for InputDataFetcher {
             .collect::<Vec<_>>();
 
         let num_so_far = data_hash_proofs_formatted.len();
-        // Extend data_hash_proofs, and last_block_id_proofs to MAX_LEAVES.
+        // Extend data_hash_proofs and last_block_id_proofs to length MAX_LEAVES.
         for _ in num_so_far..MAX_LEAVES {
             data_hash_proofs_formatted.push(InclusionProof::<
                 HEADER_PROOF_DEPTH,

--- a/circuits/vars.rs
+++ b/circuits/vars.rs
@@ -13,7 +13,6 @@ use crate::consts::*;
 #[derive(Clone, Debug, CircuitVariable)]
 #[value_name(DataCommitmentProofValueType)]
 pub struct DataCommitmentProofVariable<const MAX_LEAVES: usize> {
-    pub data_hashes: ArrayVariable<Bytes32Variable, MAX_LEAVES>,
     pub start_header: Bytes32Variable,
     pub start_block_height: U64Variable,
     pub end_header: Bytes32Variable,


### PR DESCRIPTION
Construct `data_hashes` from the `data_hash_proofs`. `data_hash_proofs`are always constrained against their corresponding headers using a merkle proof, which makes this safe usage.

Previously, we fetched `data_hashes` within a hint, and did not constrain it to be equal to the constrained leaves in `data_hash_proofs`.