### PR TITLE
fix(audit): constrain `data_comm_proof`

### DIFF
--- a/circuits/builder.rs
+++ b/circuits/builder.rs
@@ -47,8 +47,10 @@ pub trait DataCommitmentBuilder<L: PlonkParameters<D>, const D: usize> {
     fn prove_subchain<const BATCH_SIZE: usize>(
         &mut self,
         data_comm_proof: &DataCommitmentProofVariable<BATCH_SIZE>,
-        global_end_block: &U64Variable,
-        global_end_header_hash: &Bytes32Variable,
+        batch_start_block: U64Variable,
+        batch_end_block: U64Variable,
+        global_end_block: U64Variable,
+        global_end_header_hash: Bytes32Variable,
     ) -> MapReduceSubchainVariable;
 
     /// Verify the chain of headers is linked from start_block to end_block, and generate the corresponding data_merkle_root.
@@ -110,8 +112,8 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
     ) -> Bytes32Variable {
         let true_var = self._true();
         // Assert end_block >= start_block.
-        let end_block_ge_start_block = self.gte(end_block, start_block);
-        self.assert_is_equal(end_block_ge_start_block, true_var);
+        let end_block_gte_start_block = self.gte(end_block, start_block);
+        self.assert_is_equal(end_block_gte_start_block, true_var);
 
         // If end_block < start_block, then this data commitment will be marked as disabled, and the
         // output of this function is not used. Therefore, the logic assumes
@@ -150,16 +152,16 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
     fn prove_subchain<const BATCH_SIZE: usize>(
         &mut self,
         data_comm_proof: &DataCommitmentProofVariable<BATCH_SIZE>,
-        global_end_block: &U64Variable,
-        global_end_header_hash: &Bytes32Variable,
+        batch_start_block: U64Variable,
+        batch_end_block: U64Variable,
+        global_end_block: U64Variable,
+        global_end_header_hash: Bytes32Variable,
     ) -> MapReduceSubchainVariable {
         let one = self.constant::<U64Variable>(1u64);
         let true_bool = self._true();
 
-        // Get the start block, start header, end block, and end header from the data_comm_proof.
-        let batch_start_block = data_comm_proof.start_block_height;
+        // Get the start header and end header from the data_comm_proof.
         let batch_start_header_hash = data_comm_proof.start_header;
-        let batch_end_block = data_comm_proof.end_block_height;
         let batch_end_header_hash = data_comm_proof.end_header;
 
         // Path of the data_hash and last_block_id against the Tendermint header.
@@ -171,10 +173,10 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
         // If batch_start_block < global_end_block, this batch has headers that need to be verified.
         // If is_batch_enabled is false, in the reduce stage the batch will be considered empty, and
         // the right subchain's tree will be disabled in the Tendermint Merkle tree computation.
-        let is_batch_enabled = self.lt(batch_start_block, *global_end_block);
+        let is_batch_enabled = self.lt(batch_start_block, global_end_block);
         let mut curr_block_enabled = is_batch_enabled;
         let mut curr_header = batch_start_header_hash;
-        let last_block_to_process = self.sub(*global_end_block, one);
+        let last_block_to_process = self.sub(global_end_block, one);
 
         // Verify all headers in the batch. If last_block_to_process < batch_end_block, stop verifying at last_block_to_process.
         for i in 0..BATCH_SIZE {
@@ -214,7 +216,7 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
             // If this is the last valid block, verify the last_block_id_proof_root (header hash of block curr_idx+1) is equal to the global_end_header_hash.
             // This is the final step in the verification that global_start_block -> global_end_block is linked.
             let root_matches_end_header =
-                self.is_equal(last_block_id_proof_root, *global_end_header_hash);
+                self.is_equal(last_block_id_proof_root, global_end_header_hash);
             let end_header_check = self.or(is_not_last_block, root_matches_end_header);
             self.assert_is_equal(end_header_check, true_bool);
 
@@ -225,11 +227,11 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
         }
 
         // The end block of the batch's data_merkle_root is max(start_block, min(batch_end_block, global_end_block)).
-        let is_batch_end_lt_global_end = self.lte(batch_end_block, *global_end_block);
+        let is_batch_end_lt_global_end = self.lte(batch_end_block, global_end_block);
         let end_block_num = self.select(
             is_batch_end_lt_global_end,
             batch_end_block,
-            *global_end_block,
+            global_end_block,
         );
 
         let is_end_block_lt_start = self.lt(end_block_num, batch_start_block);
@@ -294,17 +296,12 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
                         map_relative_block_nums.as_vec()[BATCH_SIZE - 1],
                     );
 
-                    // The query_end_block = min(batch_end_block, global_end_block) for fetching the data commitment inputs.
-                    // If batch_end_block > global_end_block, data_comm_proof will be filled with dummy values.
-                    // This is because prove_subchain only checks up to global_end_block, and doing so reduces RPC calls.
                     let batch_end_block = builder.add(last_block, one);
-                    let past_global_end = builder.gt(batch_end_block, global_end_block);
-                    let query_end_block = builder.select(past_global_end, global_end_block, batch_end_block);
 
                     // Fetch and read the data commitment inputs.
                     let mut input_stream = VariableStream::new();
                     input_stream.write(&start_block);
-                    input_stream.write(&query_end_block);
+                    input_stream.write(&batch_end_block);
                     let data_comm_fetcher = DataCommitmentOffchainInputs::<BATCH_SIZE> {};
                     let output_stream = builder
                         .async_hint(input_stream, data_comm_fetcher);
@@ -312,7 +309,7 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
                         .read::<DataCommitmentProofVariable<BATCH_SIZE>>(builder);
 
                     // Verify the chain of headers is linked for the batch & compute the corresponding data_merkle_root.
-                    builder.prove_subchain(&data_comm_proof, &global_end_block, &global_end_header_hash)
+                    builder.prove_subchain(&data_comm_proof, start_block, batch_end_block, global_end_block, global_end_header_hash)
                 },
                 |_, left_subchain, right_subchain, builder| {
                     // The following logic handles the reduce stage of the mapreduce.
@@ -443,9 +440,7 @@ pub(crate) mod tests {
         (
             DataCommitmentProofValueType {
                 data_hashes: convert_to_h256(result.2),
-                start_block_height: (start_height as u64),
                 start_header: H256::from_slice(&result.0),
-                end_block_height: (end_height as u64),
                 end_header: H256::from_slice(&result.1),
                 data_hash_proofs: result.3,
                 last_block_id_proofs: result.4,
@@ -499,14 +494,18 @@ pub(crate) mod tests {
 
         const MAX_LEAVES: usize = 4;
         const START_BLOCK: usize = 10000;
+        let start_block = builder.constant::<U64Variable>(START_BLOCK as u64);
         const END_BLOCK: usize = START_BLOCK + MAX_LEAVES;
+        let end_block = builder.constant::<U64Variable>(END_BLOCK as u64);
 
         let data_commitment_var = builder.read::<DataCommitmentProofVariable<MAX_LEAVES>>();
 
         builder.prove_subchain::<MAX_LEAVES>(
             &data_commitment_var,
-            &data_commitment_var.end_block_height,
-            &data_commitment_var.end_header,
+            start_block,
+            end_block,
+            end_block,
+            data_commitment_var.end_header,
         );
 
         let circuit = builder.build();

--- a/circuits/data_commitment.rs
+++ b/circuits/data_commitment.rs
@@ -36,9 +36,7 @@ impl<const MAX_LEAVES: usize, L: PlonkParameters<D>, const D: usize> AsyncHint<L
 
         let data_comm_proof = DataCommitmentProofValueType {
             data_hashes: convert_to_h256(result.2),
-            start_block_height: start_block,
             start_header: H256(result.0),
-            end_block_height: end_block,
             end_header: H256(result.1),
             data_hash_proofs: result.3,
             last_block_id_proofs: result.4,

--- a/circuits/vars.rs
+++ b/circuits/vars.rs
@@ -15,9 +15,7 @@ use crate::consts::*;
 pub struct DataCommitmentProofVariable<const MAX_LEAVES: usize> {
     pub data_hashes: ArrayVariable<Bytes32Variable, MAX_LEAVES>,
     pub start_header: Bytes32Variable,
-    pub start_block_height: U64Variable,
     pub end_header: Bytes32Variable,
-    pub end_block_height: U64Variable,
     pub data_hash_proofs: ArrayVariable<
         MerkleInclusionProofVariable<HEADER_PROOF_DEPTH, PROTOBUF_HASH_SIZE_BYTES>,
         MAX_LEAVES,


### PR DESCRIPTION
## Changes
### prove_subchain
- Explicitly pass in `batch_start_block` and `batch_end_block` into `prove_subchain`.
- Update call to `get_data_commitment` to reflect new constraint that `end_block` >= `start_block`. `end_block_num` is now max(batch_start_block, min(batch_end_block, global_end_block))
- Constrain the outputs of `prove_subchain` to equal the supplied inputs of `start_block`, `start_header_hash`, `end_block` and `end_header_hash`.
   - This constraint validates the computation over the intermediate headers.


### get_data_commitment
- Assert that `end_block` >= `start_block` so that `nb_enabled_leaves` can't overflow, and assert that `nb_enabled_leaves` < 2^32.