### PR TITLE
fix(audit): constrain end block too far

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ alloy-primitives = "0.4.2"
 alloy-sol-types = "0.4.2"
 anyhow = "1.0.71"
 async-trait = "0.1.73"
-clap = {version = "4.3.18", features = ["derive"]}
+clap = { version = "4.3.18", features = ["derive"] }
 digest = "0.10.7"
 dotenv = "0.15.0"
 ed25519-consensus = "2.1.0"
@@ -61,15 +61,15 @@ futures = "0.3.30"
 itertools = "0.11.0"
 log = "0.4.19"
 num = "0.4.1"
-plonky2x = {git = "https://github.com/succinctlabs/succinctx.git"}
+plonky2x = { git = "https://github.com/succinctlabs/succinctx.git" }
 rand = "0.8.5"
 reqwest = "0.11.18"
 serde = "1.0.175"
 serde_json = "1.0.103"
 sha2 = "0.10.7"
 subtle-encoding = "0.5.1"
-succinct-client = {git = "https://github.com/succinctlabs/succinctx.git"}
+succinct-client = { git = "https://github.com/succinctlabs/succinctx.git" }
 tendermint = "0.33.0"
 tendermint-proto = "0.33.0"
-tendermintx = {git = "https://github.com/succinctlabs/tendermintx.git"}
-tokio = {version = "1.29.1", features = ["full"]}
+tendermintx = { git = "https://github.com/succinctlabs/tendermintx.git" }
+tokio = { version = "1.29.1", features = ["full"] }

--- a/circuits/builder.rs
+++ b/circuits/builder.rs
@@ -254,6 +254,13 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
         };
 
         let max_num_blocks = NB_MAP_JOBS * BATCH_SIZE;
+        // Assert end_block <= start_block + NB_MAP_JOBS + BATCH_SIZE.
+        let true_v = self._true();
+        let max_num_blocks_v = self.constant::<U64Variable>(max_num_blocks as u64);
+        let start_plus_max_num_blocks = self.add(start_block, max_num_blocks_v);
+        let end_block_check = self.lte(end_block, start_plus_max_num_blocks);
+        self.assert_is_equal(end_block_check, true_v);
+
         let relative_block_nums = (0u64..(max_num_blocks as u64)).collect::<Vec<_>>();
 
         let result = self

--- a/circuits/builder.rs
+++ b/circuits/builder.rs
@@ -254,7 +254,7 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
         };
 
         let max_num_blocks = NB_MAP_JOBS * BATCH_SIZE;
-        // Assert end_block <= start_block + NB_MAP_JOBS + BATCH_SIZE.
+        // Assert end_block <= start_block + NB_MAP_JOBS * BATCH_SIZE.
         let true_v = self._true();
         let max_num_blocks_v = self.constant::<U64Variable>(max_num_blocks as u64);
         let start_plus_max_num_blocks = self.add(start_block, max_num_blocks_v);


### PR DESCRIPTION
Assert `end_block` <= `start_block` + NB_MAP_JOBS + BATCH_SIZE.
