### PR TITLE
fix: `prove_subchain` outputs

### DIFF
--- a/circuits/builder.rs
+++ b/circuits/builder.rs
@@ -370,14 +370,26 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
                         computed_data_merkle_root,
                     );
 
+                    // If the right_subchain is disabled, use left_subchain end_block & end_header.
+                    let end_block = builder.select(
+                        is_right_subchain_disabled,
+                        left_subchain.end_block,
+                        right_subchain.end_block,
+                    );
+                    let end_header = builder.select(
+                        is_right_subchain_disabled,
+                        left_subchain.end_header,
+                        right_subchain.end_header,
+                    );
+
                     MapReduceSubchainVariable {
-                        // If the left_subchain is disabled, then the right_subchain is disabled and
-                        // this combined subchain is disabled (and the data_merkle_root is not used).
+                        // If the left_subchain is disabled, then the right_subchain is also disabled. 
+                        // So, use the left_subchain's is_enabled.
                         is_enabled: left_subchain.is_enabled,
                         start_block: left_subchain.start_block,
                         start_header: left_subchain.start_header,
-                        end_block: right_subchain.end_block,
-                        end_header: right_subchain.end_header,
+                        end_block,
+                        end_header,
                         data_merkle_root,
                     }
                 },

--- a/circuits/builder.rs
+++ b/circuits/builder.rs
@@ -231,7 +231,7 @@ impl<L: PlonkParameters<D>, const D: usize> DataCommitmentBuilder<L, D> for Circ
         self.assert_is_equal(end_header_check, true_bool);
 
         // The end block of the batch's data_merkle_root is max(start_block, min(batch_end_block, global_end_block)).
-        let is_batch_end_lt_global_end = self.lte(batch_end_block, global_end_block);
+        let is_batch_end_lt_global_end = self.lt(batch_end_block, global_end_block);
         let temp_end_block_num = self.select(
             is_batch_end_lt_global_end,
             batch_end_block,

--- a/circuits/header_range.rs
+++ b/circuits/header_range.rs
@@ -191,7 +191,7 @@ mod tests {
         // Test variable length NUM_BLOCKS.
         const MAX_VALIDATOR_SET_SIZE: usize = 8;
         const NB_MAP_JOBS: usize = 2;
-        const BATCH_SIZE: usize = 2;
+        const BATCH_SIZE: usize = 4;
 
         // These blocks are on Mocha-4 testnet.
         let start_block = 500u64;


### PR DESCRIPTION
Return the correct outputs from `prove_subchain`. The `data_commitment` generated was incorrect, but the constraints that were verifying the `start_block`, `start_header`, `end_block` and `end_header` were failing.