### PR TITLE
feat: increase `SKIP_MAX` to 2048

### DIFF
--- a/circuits/consts.rs
+++ b/circuits/consts.rs
@@ -24,4 +24,4 @@ pub const DATA_HASH_INDEX: usize = 6;
 
 // Constants for the header range circuit.
 pub const NB_MAP_JOBS: usize = 64;
-pub const BATCH_SIZE: usize = 16;
+pub const BATCH_SIZE: usize = 32;

--- a/contracts/src/BlobstreamX.sol
+++ b/contracts/src/BlobstreamX.sol
@@ -16,9 +16,9 @@ contract BlobstreamX is IBlobstreamX, IDAOracle, TimelockedUpgradeable {
     /// @notice The block is the first one in the next data commitment.
     uint64 public latestBlock;
 
-    /// @notice The maximum number of blocks that can be skipped in a single request.
-    /// Source: https://github.com/celestiaorg/celestia-core/blob/main/pkg/consts/consts.go#L43-L44
-    uint64 public constant DATA_COMMITMENT_MAX = 1000;
+    /// @notice The maximum number of blocks that can be skipped in a single request. Should be
+    /// large enough to skip forward at least 4 hours.
+    uint64 public constant DATA_COMMITMENT_MAX = 2048;
 
     /// @notice Nonce for proof events. Must be incremented sequentially.
     uint256 public state_proofNonce;


### PR DESCRIPTION
To submit batches of blocks every 4 hours, we need to increase `SKIP_MAX` for `BlobstreamX` to 2048 blocks (greater than the 1200 blocks that pass every 4 hours).