### PR TITLE
fix: input

### DIFF
--- a/circuits/input.rs
+++ b/circuits/input.rs
@@ -113,8 +113,7 @@ impl DataCommitmentInputFetcher for InputDataFetcher {
         v.result.signed_header.header.height.into()
     }
 
-    // start_block_number and end_block_number aren't guaranteed to be less than the latest_signed_header.
-    // Fetch the latest signed header, and use it to determine the actual range of signed headers to fetch.
+    // Assumes start_block_number and end_block_number are less than or equal to the latest block number.
     async fn get_signed_header_range(
         &self,
         start_block_number: u64,

--- a/circuits/input.rs
+++ b/circuits/input.rs
@@ -52,6 +52,7 @@ pub trait DataCommitmentInputFetcher {
         end_block_number: u64,
     ) -> Vec<SignedHeader>;
 
+    /// start_block_number and end_block_number are not guaranteed to be less than the latest_block.
     async fn get_data_commitment_inputs<const MAX_LEAVES: usize, F: RichField>(
         &mut self,
         start_block_number: u64,
@@ -150,6 +151,8 @@ impl DataCommitmentInputFetcher for InputDataFetcher {
         start_block_number: u64,
         end_block_number: u64,
     ) -> DataCommitmentInputs<F> {
+        assert!(end_block_number - start_block_number < MAX_LEAVES as u64);
+
         let mut data_hash_proofs = Vec::new();
         let mut last_block_id_proofs = Vec::new();
 

--- a/circuits/input.rs
+++ b/circuits/input.rs
@@ -151,7 +151,7 @@ impl DataCommitmentInputFetcher for InputDataFetcher {
         start_block_number: u64,
         end_block_number: u64,
     ) -> DataCommitmentInputs<F> {
-        assert!(end_block_number - start_block_number < MAX_LEAVES as u64);
+        assert!(end_block_number - start_block_number <= MAX_LEAVES as u64);
 
         let mut data_hash_proofs = Vec::new();
         let mut last_block_id_proofs = Vec::new();

--- a/circuits/input.rs
+++ b/circuits/input.rs
@@ -44,6 +44,8 @@ pub trait DataCommitmentInputFetcher {
     async fn get_latest_block_number(&self) -> u64;
 
     /// Get signed headers in the range [start_block_number, end_block_number] inclusive.
+    /// Note: Assumes start_block_number and end_block_number are less than or equal to the latest
+    /// block number.
     async fn get_signed_header_range(
         &self,
         start_block_number: u64,
@@ -287,7 +289,7 @@ mod tests {
         let mut fetcher = InputDataFetcher::default();
         let start_block = 3000000;
         let end_block = 3000010;
-        let data_commitment_inputs = fetcher
+        let _ = fetcher
             .get_data_commitment_inputs::<32, F>(start_block, end_block)
             .await;
     }

--- a/circuits/input.rs
+++ b/circuits/input.rs
@@ -265,3 +265,31 @@ impl DataCommitmentInputFetcher for InputDataFetcher {
         }
     }
 }
+#[cfg(test)]
+mod tests {
+
+    use std::env;
+
+    use plonky2x::backend::circuit::{DefaultParameters, PlonkParameters};
+
+    use super::*;
+
+    const D: usize = 2;
+    type L = DefaultParameters;
+    type F = <L as PlonkParameters<D>>::Field;
+
+    // Ensure that get_data_commitment_inputs doesn't fail with inputs greater than the latest block.
+    #[cfg_attr(feature = "ci", ignore)]
+    #[tokio::test]
+    async fn test_get_data_commitment_inputs() {
+        env_logger::init();
+        env::set_var("RUST_LOG", "debug");
+        dotenv::dotenv().ok();
+        let mut fetcher = InputDataFetcher::default();
+        let start_block = 3000000;
+        let end_block = 3000010;
+        let data_commitment_inputs = fetcher
+            .get_data_commitment_inputs::<32, F>(start_block, end_block)
+            .await;
+    }
+}


### PR DESCRIPTION
Only fetch headers for blocks less than the latest block. Otherwise, input fetching will fail.