### PR TITLE
docs: update contracts/README.md

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -36,7 +36,7 @@ forge script script/Deploy.s.sol --rpc-url $RPC_URL --private-key $PRIVATE_KEY -
 In addition to the fields in `.env` for deployment, fill out the following fields in `.env` in `contracts` folder:
 
 - `CONTRACT_ADDRESS` - Address of the contract to upgrade
-- `UPGRADE` - Set to `true` to upgrade the contract
+- `UPGRADE` - Set to `true` to upgrade the contract, and don't set `DEPLOY` to `true`
 - `UPDATE_GENESIS_STATE` - Set to true to update the genesis state of the contract using `GENESIS_HEIGHT` and `GENESIS_HEADER`.
 - `UPDATE_GATEWAY` - Set to true to update the gateway address of the contract using `GATEWAY_ADDRESS`.
 - `UPDATE_FUNCTION_IDS` - Set to true to update the function IDs of the contract using `NEXT_HEADER_FUNCTION_ID` and `HEADER_RANGE_FUNCTION_ID`.


### PR DESCRIPTION
I want to upgrade the contract, and follow the docs to set all the env variables to .env, but it always goes to `deploy`, not `upgrade`.

I find that `upgrade` takes affect iff set `UPGRADE=true` && `DEPLOY=false`.

So imo it's better to update README.md.