### PR TITLE
refactor: .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 # Ethereum config
 PRIVATE_KEY=
 RPC_URL=
-ETHERSCAN_API_KEY=
 
 # Tendermint config. Accepts comma separated list of RPC URLs for failover.
 TENDERMINT_RPC_URL=


### PR DESCRIPTION
Remove unnecessary `.env` variables.